### PR TITLE
fixed file_id size in common.c

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -760,7 +760,7 @@ int fdfs_http_request_handler(struct fdfs_http_context *pContext)
 #define HTTPD_MAX_PARAMS   32
 	char *file_id_without_group;
 	char *url;
-	char file_id[128];
+	char file_id[530];
 	char uri[512];
 	int url_len;
 	int uri_len;


### PR DESCRIPTION
set `file_id`'s size to 128 in function `fdfs_http_request_handler` will result in format-truncation warning in newer version gcc.

The most corner case of the length of bytes written to array `file_id` is 528 at `src/common.c:903` determined by GCC. So set to 530 to get the compile error solved.