### PR TITLE
anti-steal check bypass feature new

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -1,10 +1,10 @@
 /**
-* Copyright (C) 2008 Happy Fish / YuQing
-*
-* FastDFS may be copied only under the terms of the GNU General
-* Public License V3, which may be found in the FastDFS source kit.
-* Please visit the FastDFS Home Page http://www.fastken.com/ for more detail.
-**/
+ * Copyright (C) 2008 Happy Fish / YuQing
+ *
+ * FastDFS may be copied only under the terms of the GNU General
+ * Public License V3, which may be found in the FastDFS source kit.
+ * Please visit the FastDFS Home Page http://www.fastken.com/ for more detail.
+ **/
 
 
 #include <sys/types.h>
@@ -64,6 +64,8 @@ static char response_mode = FDFS_MOD_REPONSE_MODE_PROXY;
 static GroupStorePaths *group_store_paths = NULL;   //for multi groups
 static FDFSHTTPParams g_http_params;
 static int storage_sync_file_max_delay = 24 * 3600;
+static char bypass_header_name[256];
+static char bypass_header_value[256];
 
 static int fdfs_get_params_from_tracker();
 static int fdfs_format_http_datetime(time_t t, char *buff, const int buff_size);
@@ -102,12 +104,11 @@ static int fdfs_load_groups_store_paths(IniContext *pItemContext)
 		return errno != 0 ? errno : ENOMEM;
 	}
 
-    memcpy(section_name, FDFS_GROUP_PREFIX_STR, FDFS_GROUP_PREFIX_LEN);
+	memcpy(section_name, FDFS_GROUP_PREFIX_STR, FDFS_GROUP_PREFIX_LEN);
 	for (i=0; i<group_count; i++)
 	{
-        fc_ltostr(i + 1, section_name + FDFS_GROUP_PREFIX_LEN);
-		pGroupName = iniGetStrValue(section_name,
-                "group_name", pItemContext);
+		fc_ltostr(i + 1, section_name + FDFS_GROUP_PREFIX_LEN);
+		pGroupName = iniGetStrValue(section_name, "group_name", pItemContext);
 		if (pGroupName == NULL)
 		{
 			logError("file: "__FILE__", line: %d, " \
@@ -121,7 +122,7 @@ static int fdfs_load_groups_store_paths(IniContext *pItemContext)
 			FDFS_STORAGE_SERVER_DEF_PORT);
 
 		group_store_paths[i].group_name_len = fc_safe_strcpy(
-                group_store_paths[i].group_name, pGroupName);
+			group_store_paths[i].group_name, pGroupName);
 		if (group_store_paths[i].group_name_len == 0)
 		{
 			logError("file: "__FILE__", line: %d, " \
@@ -129,7 +130,7 @@ static int fdfs_load_groups_store_paths(IniContext *pItemContext)
 				"can't be empty!", __LINE__, section_name);
 			return EINVAL;
 		}
-		
+
 		group_store_paths[i].store_paths.paths = \
 			storage_load_paths_from_conf_file_ex(pItemContext, \
 			section_name, false, &group_store_paths[i].store_paths.count, \
@@ -324,6 +325,21 @@ int fdfs_mod_init()
 		}
 	}
 
+	char *bypassHeader;
+	bypassHeader = iniGetStrValue(NULL, "anti_steal_bypass_header_name", \
+					&iniContext);
+	if (bypassHeader != NULL)
+	{
+		fc_safe_strcpy(bypass_header_name, bypassHeader);
+
+		char *bypassHeaderValue;
+		bypassHeaderValue = iniGetStrValue(NULL, "anti_steal_bypass_header_value", \
+					&iniContext);
+		if (bypassHeaderValue != NULL){
+			fc_safe_strcpy(bypass_header_value, bypassHeaderValue);
+		}
+	}
+
 	iniFreeContext(&iniContext);
 	if (result != 0)
 	{
@@ -353,7 +369,7 @@ int fdfs_mod_init()
 		}
 	}
 
-	logInfo("fastdfs apache / nginx module v1.25, "
+	logInfo("fastdfs apache / nginx module v1.26, "
 		"response_mode=%s, "
 		"base_path=%s, "
 		"url_have_group_name=%d, "
@@ -830,7 +846,7 @@ int fdfs_http_request_handler(struct fdfs_http_context *pContext)
 	int result;
 	int http_status;
 	int the_storage_port;
-    int i;
+	int i;
 	struct fdfs_http_response response;
 	FDFSFileInfo file_info;
 	bool bFileExists;
@@ -964,45 +980,57 @@ int fdfs_http_request_handler(struct fdfs_http_context *pContext)
 		char *ts;
 		int timestamp;
 
-		token = fdfs_http_get_parameter("token", params, param_count);
-		ts = fdfs_http_get_parameter("ts", params, param_count);
-		if (token == NULL || ts == NULL)
+		char val_buf[1024];
+		const char *val = pContext->get_request_header(pContext->arg, bypass_header_name, val_buf, sizeof(val_buf));
+		if (val && strcmp(val, bypass_header_value) == 0)
 		{
-			logError("file: "__FILE__", line: %d, " \
-				"expect parameter token or ts in url, " \
-				"uri: %s", __LINE__, uri);
-			OUTPUT_HEADERS(pContext, (&response), HTTP_BADREQUEST);
-			return HTTP_BADREQUEST;
+			logDebug("file: " __FILE__ \
+					 ", line: %d, " \
+					 "Skip check bcz found bypass_header, uri: %s", \
+					 __LINE__, uri);
 		}
+		else
+		{
+			token = fdfs_http_get_parameter("token", params, param_count);
+			ts = fdfs_http_get_parameter("ts", params, param_count);
+			if (token == NULL || ts == NULL)
+			{
+				logError("file: "__FILE__", line: %d, " \
+					"expect parameter token or ts in url, " \
+					"uri: %s", __LINE__, uri);
+				OUTPUT_HEADERS(pContext, (&response), HTTP_BADREQUEST);
+				return HTTP_BADREQUEST;
+			}
 
-		timestamp = atoi(ts);
-		if ((result=fdfs_http_check_token( \
+			timestamp = atoi(ts);
+			if ((result=fdfs_http_check_token( \
 				&g_http_params.anti_steal_secret_key, \
 				file_id_without_group, timestamp, token, \
 				g_http_params.token_ttl)) != 0)
-		{
-			logError("file: "__FILE__", line: %d, " \
+			{
+				logError("file: "__FILE__", line: %d, " \
 				"check token fail, uri: %s, " \
 				"errno: %d, error info: %s", \
 				__LINE__, uri, result, STRERROR(result));
-			if (*(g_http_params.token_check_fail_content_type))
-			{
-				response.content_length = g_http_params. \
+				if (*(g_http_params.token_check_fail_content_type))
+				{
+					response.content_length = g_http_params. \
 						token_check_fail_buff.length;
-				response.content_type = g_http_params. \
+					response.content_type = g_http_params. \
 						token_check_fail_content_type;
-				OUTPUT_HEADERS(pContext, (&response), HTTP_OK);
+					OUTPUT_HEADERS(pContext, (&response), HTTP_OK);
 
-				pContext->send_reply_chunk(pContext->arg, 1, \
-					g_http_params.token_check_fail_buff.buff, 
-					g_http_params.token_check_fail_buff.length);
+					pContext->send_reply_chunk(pContext->arg, 1, \
+						g_http_params.token_check_fail_buff.buff, 
+						g_http_params.token_check_fail_buff.length);
 
-				return HTTP_OK;
-			}
-			else
-			{
-				OUTPUT_HEADERS(pContext, (&response), HTTP_BADREQUEST);
-				return HTTP_BADREQUEST;
+					return HTTP_OK;
+				}
+				else
+				{
+					OUTPUT_HEADERS(pContext, (&response), HTTP_BADREQUEST);
+					return HTTP_BADREQUEST;
+				}
 			}
 		}
 	}

--- a/src/common.h
+++ b/src/common.h
@@ -69,6 +69,7 @@ extern "C" {
 
 struct fdfs_http_response;
 
+typedef const char* (*FDFSGetRequestHeader)(void *arg, const char *name, char *value_buf, size_t buf_size);
 typedef void (*FDFSOutputHeaders)(void *arg, struct fdfs_http_response *pResponse);
 typedef int (*FDFSSendReplyChunk)(void *arg, const bool last_buff, \
 				const char *buff, const int size);
@@ -119,6 +120,7 @@ struct fdfs_http_context {
 	char *url;
 	void *arg; //for callback
 	FDFSOutputHeaders output_headers;
+	FDFSGetRequestHeader get_request_header;
 	FDFSSendFile send_file;   //nginx send file
 	FDFSSendReplyChunk send_reply_chunk;
 	FDFSProxyHandler proxy_handler; //nginx proxy handler

--- a/src/mod_fastdfs.conf
+++ b/src/mod_fastdfs.conf
@@ -130,3 +130,9 @@ group_count = 0
 #storage_server_port=23000
 #store_path_count=1
 #store_path0=/home/yuqing/fastdfs
+
+# custom request header to bypass anti-steal check.
+# example Nginx usage: proxy_set_header MY-HEADER 'MY-MARK'
+# disabled if commented out.
+#anti_steal_bypass_header_name=MY-HEADER
+#anti_steal_bypass_header_value=MY-MARK


### PR DESCRIPTION
This feature is used to skip the anti-steal check in some internal requests to fastdfs module.
Compared to the previous PR, I move some code to ngx_http_fastdfs_module.c
In my use case, the nginx-vod-module requests mp4 files from the fastdfs-nginx-module. It is difficult to generate anti-steal parameters for these requests.